### PR TITLE
support code_challenge_method parameter

### DIFF
--- a/lib/ex_oauth2_provider/applications/strategies/sql_strategy.ex
+++ b/lib/ex_oauth2_provider/applications/strategies/sql_strategy.ex
@@ -105,11 +105,11 @@ defmodule ExOauth2Provider.Applications.Strategy.SqlStrategy do
     |> Config.repo(config).get_by(uid: uid, secret: client_secret)
   end
 
-  def load_application(uid, {:code_verifier, code_verifier}, config) do
+  def load_application(uid, {:code_verifier, code_verifier, code_challenge_method}, config) do
     config
     |> Config.application()
     |> Config.repo(config).get_by(uid: uid)
-    |> verify_pkce(code_verifier, config)
+    |> verify_pkce(code_verifier, code_challenge_method, config)
   end
 
   def load_application(uid, :refresh_token_flow, config) do
@@ -122,10 +122,10 @@ defmodule ExOauth2Provider.Applications.Strategy.SqlStrategy do
     end
   end
 
-  defp verify_pkce(nil, _code_verifier, _config), do: nil
+  defp verify_pkce(nil, _code_verifier, _code_challenge_method, _config), do: nil
 
-  defp verify_pkce(application, code_verifier, config) do
-    case Config.pkce_module(config).verify(application, code_verifier) do
+  defp verify_pkce(application, code_verifier, code_challenge_method, config) do
+    case Config.pkce_module(config).verify(application, code_verifier, code_challenge_method) do
       :ok ->
         application
 

--- a/lib/ex_oauth2_provider/oauth2/authorization/utils/pkce.ex
+++ b/lib/ex_oauth2_provider/oauth2/authorization/utils/pkce.ex
@@ -13,22 +13,31 @@ defmodule ExOauth2Provider.Authorization.Utils.Pkce do
     end
   end
 
-  @callback verify(Application.t(), binary()) :: :ok | {:error, String.t()}
-  @spec verify(Application.t(), binary()) :: :ok | {:error, String.t()}
-  def verify(application, code_verifier) do
-    hash =
-      :crypto.hash(:sha256, code_verifier)
-      |> :binary.decode_unsigned()
-
-    code_challenge =
-      :io_lib.format("~64.16.0b", [hash])
-      |> to_string()
-      |> Base.encode64()
+  @callback verify(Application.t(), binary(), code_challenge_method :: String.t()) ::
+              :ok | {:error, String.t()}
+  @spec verify(Application.t(), binary(), code_challenge_method :: String.t()) ::
+          :ok | {:error, String.t()}
+  def verify(application, code_verifier, code_challenge_method) do
+    code_challenge = generate_code_challenge(code_verifier, code_challenge_method)
 
     if application.uid <> code_challenge == Agent.get(__MODULE__, & &1) do
       :ok
     else
       {:error, "invalid code verfier"}
     end
+  end
+
+  @doc """
+  Generates a code challenge string given `code_verifier` and `code_challenge_method`.
+  Supports "plain" and "S256" `code_challenge_method`.
+  """
+  @spec generate_code_challenge(code_verifier :: String.t(), code_challenge_method :: String.t()) ::
+          String.t()
+  def generate_code_challenge(code_verifier, "plain"), do: code_verifier
+
+  def generate_code_challenge(code_verifier, "S256") do
+    :sha256
+    |> :crypto.hash(code_verifier)
+    |> Base.url_encode64()
   end
 end

--- a/lib/ex_oauth2_provider/oauth2/token/utils.ex
+++ b/lib/ex_oauth2_provider/oauth2/token/utils.ex
@@ -18,7 +18,8 @@ defmodule ExOauth2Provider.Token.Utils do
               end
 
             code_verifier ->
-              {:code_verifier, code_verifier}
+              code_challenge_method = Map.get(request, "code_challenge_method")
+              {:code_verifier, code_verifier, code_challenge_method}
           end
 
         client_secret ->

--- a/lib/ex_oauth2_provider/plug/store_code_challenge.ex
+++ b/lib/ex_oauth2_provider/plug/store_code_challenge.ex
@@ -14,7 +14,9 @@ defmodule ExOauth2Provider.Plug.StoreCodeChallenge do
   defp ensure_code_challenge(conn, config) do
     case conn.params do
       %{"client_id" => client_id, "code_challenge" => code_challenge} ->
-        Config.pkce_module(config).store(client_id, code_challenge)
+        code_challenge_method = Map.get(conn.params, "code_challenge_method")
+        Config.pkce_module(config).store(client_id, code_challenge, code_challenge_method)
+
         conn
 
       _ ->

--- a/test/ex_oauth2_provider/applications/applications_test.exs
+++ b/test/ex_oauth2_provider/applications/applications_test.exs
@@ -1,6 +1,7 @@
 defmodule ExOauth2Provider.ApplicationsTest do
   use ExOauth2Provider.TestCase
 
+  alias ExOauth2Provider.Authorization.Utils.Pkce
   alias ExOauth2Provider.Test.Fixtures
   alias ExOauth2Provider.{AccessTokens, Applications}
   alias Dummy.{OauthApplications.OauthApplication, OauthAccessTokens.OauthAccessToken, Repo}
@@ -76,6 +77,21 @@ defmodule ExOauth2Provider.ApplicationsTest do
 
       assert %OauthApplication{id: id} =
                Applications.load_application(application.uid, {:client_secret, :not_required},
+                 otp_app: :ex_oauth2_provider
+               )
+
+      assert id == application.id
+    end
+
+    test "loading via code verifier", %{application: application} do
+      code_verifier = "this_is_the_code_verifier"
+      code_challenge = Pkce.generate_code_challenge(code_verifier, "S256")
+      Pkce.store(application.uid, code_challenge)
+
+      assert %OauthApplication{id: id} =
+               Applications.load_application(
+                 application.uid,
+                 {:code_verifier, code_verifier, "S256"},
                  otp_app: :ex_oauth2_provider
                )
 


### PR DESCRIPTION
pass the `code_challenge_method` parameter through the PKCE pipeline to support different hashing algorithms